### PR TITLE
LTI-109: Unable to register the same LTI 1.3 app on the same consumer using different tenants

### DIFF
--- a/app/models/rails_lti2_provider/tool.rb
+++ b/app/models/rails_lti2_provider/tool.rb
@@ -2,7 +2,8 @@
 
 module RailsLti2Provider
   class Tool < ApplicationRecord
-    validates :shared_secret, :uuid, :tool_settings, :lti_version, presence: true
+    validates :tool_settings, :lti_version, presence: true
+    validates :uuid, uniqueness: { scope: [:shared_secret, :deployment_id], message: "Tool already exists"}
     serialize :tool_settings
     belongs_to :tenant, inverse_of: :tools
     has_many :lti_launches, dependent: :restrict_with_exception

--- a/db/migrate/20201029132554_add_rails_lti2_provider_tool_deployment_id.rb
+++ b/db/migrate/20201029132554_add_rails_lti2_provider_tool_deployment_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRailsLti2ProviderToolDeploymentId < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:rails_lti2_provider_tools, :deployment_id, :text)
+  end
+end

--- a/db/migrate/20201029133815_update_rails_lti2_provider_tool_index_deploy.rb
+++ b/db/migrate/20201029133815_update_rails_lti2_provider_tool_index_deploy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class UpdateRailsLti2ProviderToolIndexDeploy < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index('rails_lti2_provider_tools', %w[uuid shared_secret deployment_id], name: 'index_deployment', unique: true)
+    remove_index('rails_lti2_provider_tools', ['uuid'])
+  end
+
+  def self.down
+    add_index('rails_lti2_provider_tools', ['uuid'], name: 'index_uuid', unique: true)
+    remove_index('rails_lti2_provider_tools', %w[uuid shared_secret deployment_id])
+  end
+end


### PR DESCRIPTION
Changes the unique index of [uuid] to [uuid, client_id, deployment] to signify a tool 