### PR TITLE
LTI-155: updated ims-lti gem to bn/fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+gem 'ims-lti', git: 'https://github.com/blindsidenetworks/ims-lti.git', tag: 'v2.3.2.1'
+
 # Declare your gem's dependencies in rails_lti2_provider.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.

--- a/lib/rails_lti2_provider/version.rb
+++ b/lib/rails_lti2_provider/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsLti2Provider
-  VERSION = '0.1.3'
+  VERSION = '0.1.3.1'
 end

--- a/rails_lti2_provider.gemspec
+++ b/rails_lti2_provider.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
 
-  s.add_dependency('ims-lti', '~> 2.3.1')
   s.add_dependency('rails', '~> 6.0.3')
 
   s.add_development_dependency('rspec-rails', '~> 4.0')


### PR DESCRIPTION
LTI-155: updated ims-lti gem to bn/fork to cascade use of fork for simple_oauth gem and add support for HMAC-SHA256/SHA384/SHA512 signature methods